### PR TITLE
fix page size to include footers in bottom margin

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -1,5 +1,13 @@
 %  University of Houston MS/PhD template
-\documentclass[12pt]{report}
+\documentclass[12pt,letterpaper]{report}
+\usepackage[letterpaper,
+   left=1.5in, right=1.0in,
+   % Add extra room for footer (bottom is more than the 1 inch
+   % minimum). It is better to overestimate than have to
+   % re-submit.
+   top=1.0in, bottom=1.25in,
+   includefoot, % use includefoot because the bottom margin includes the page numbers
+   heightrounded]{geometry}
 \usepackage{uhthesis3}
 
 \setcounter{secnumdepth}{4}

--- a/uhthesis3.sty
+++ b/uhthesis3.sty
@@ -114,15 +114,6 @@ Documentation:
 \@ifundefined{chapter}{\@latexerr{The `uhthesis' option should be used
 with the `report' document style}}{}
 
-% We need 1 1/2" margins except on the right edge, where it is 1"
-% Theses are single-sided, so we don't care about \evensidemargin
-\oddsidemargin 0.5in \evensidemargin 0in
-%\marginparwidth 40pt \marginparsep 10pt
-\topmargin 0in
-\headsep 0.4in
-\textheight 8in
-\textwidth 5.95in
-
 % Disallow page breaks at hyphens (this will give some underfull vbox's,
 % so an alternative is to use \brokenpenalty=100 and manually search
 % for and fix such page breaks)


### PR DESCRIPTION
The margins for the NSM guidelines _include_ the footer where the page
numbers are. By default, LaTeX does not measure this part when setting
up margins.

This removes the settings from `uhthesis3.sty`.
